### PR TITLE
Building and publishing improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ apply plugin: "signing"
 
 group = "org.opensextant"
 version = "2.0.1-SNAPSHOT"
+ext.isReleaseVersion = !version.endsWith('-SNAPSHOT')
 sourceCompatibility = 1.6
 javadoc.options.encoding = compileJava.options.encoding = 'ISO-8859-1'
 
@@ -67,6 +68,7 @@ artifacts {
 }
 
 signing {
+	required isReleaseVersion
 	sign configurations.archives
 }
 


### PR DESCRIPTION
I brought over GISCore's publishing improvements and made some tweaks to fix building on non-Windows machines.  The compiled code now targets Java 6 and you don't need a GPG key to publish a non-release version.
